### PR TITLE
Sensitive graphdb.properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v0.8.2](https://github.com/phaedriel/puppet-graphdb/releases/tag/v0.8.2)
+
+- Drop debian 10 (metadata.json)
+- Use Sensitive for graphdb.properties
+
 ## [v0.8.1](https://github.com/phaedriel/puppet-graphdb/releases/tag/v0.8.1)
 
 - Rubocop corrections

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -179,7 +179,7 @@ define graphdb::instance (
 
     file { "${instance_home_dir}/conf/graphdb.properties":
       ensure  => $ensure,
-      content => template('graphdb/config/graphdb.properties.erb'),
+      content => Sensitive(template('graphdb/config/graphdb.properties.erb')),
       notify  => Service[$service_name],
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "phaedriel-graphdb",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "ontotext",
   "summary": "Module for managing and configuring GraphDB instances",
   "license": "Apache-2.0",
@@ -29,7 +29,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -65,13 +65,13 @@ describe 'graphdb::instance', type: :define do
                 notify:  "Service[graphdb-#{title}]",
                 owner: 'graphdb',
                 group: 'graphdb',
-                content: "graphdb.connector.port = 8080
+                content: sensitive("graphdb.connector.port = 8080
 graphdb.extra.plugins = /var/lib/graphdb/test/plugins
 graphdb.home.data = /var/lib/graphdb/test
 graphdb.home.logs = /var/log/graphdb/test
 graphdb.license.file = /opt/graphdb/instances/test/license
 graphdb.workbench.importDirectory = /opt/graphdb/import
-")
+"))
       end
       it {    is_expected.to contain_graphdb__service(title).with(ensure: 'present', status: 'enabled') }
       it {    is_expected.to contain_graphdb_validator("graphdb-#{title}").with(endpoint: 'http://129.10.1.1:8080') }
@@ -113,7 +113,7 @@ graphdb.workbench.importDirectory = /opt/graphdb/import
         .with(ensure: 'present',
               owner: 'graphdb',
               group: 'graphdb',
-              content: /graphdb.connector.port = 9090/)
+              content: sensitive(/graphdb.connector.port = 9090/))
     end
     it { is_expected.to contain_graphdb_validator("graphdb-#{title}").with(endpoint: 'http://129.10.1.1:9090') }
   end
@@ -176,7 +176,7 @@ graphdb.workbench.importDirectory = /opt/graphdb/import
 
     it do
       is_expected.to contain_file('/opt/graphdb/instances/test/conf/graphdb.properties')
-        .with(content: /test_property = test_property_value/)
+        .with(content: sensitive(/test_property = test_property_value/))
     end
   end
 end


### PR DESCRIPTION
- Drop debian 10 (metadata.json)
- Use Sensitive for graphdb.properties